### PR TITLE
Fix "scribe-common" dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "scribe-plugin-smart-lists",
   "dependencies": {
-    "lodash-amd": "2.4.1",
     "scribe-common": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "main": "src/scribe-plugin-smart-lists.js",
   "dependencies": {
+    "scribe-common": "~0.0.3"
   },
   "devDependencies": {
     "chai": "~1.9.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.2",
   "main": "src/scribe-plugin-smart-lists.js",
   "dependencies": {
-    "lodash-amd": "~2.4.1"
   },
   "devDependencies": {
     "chai": "~1.9.1",


### PR DESCRIPTION
The package on npm does not depend on `scribe-common`, however the source code for this plugin attempts to load `scribe-common/element`.

In addition, `lodash-amd` was declared as a dependency but was not used in this plugin, so removed that as a dependency.

A re-publish to npm after this would be much appreciated! :beers: 