### PR TITLE
Append BR element

### DIFF
--- a/src/scribe-plugin-smart-lists.js
+++ b/src/scribe-plugin-smart-lists.js
@@ -55,6 +55,16 @@ define(['scribe-common/src/element'], function (element) {
             parentNode.removeChild(textNode.previousSibling);
           }
           parentNode.removeChild(textNode);
+          /**
+           * Chrome: Sometimes a BR is not inserted. Unable to reproduce in the
+           * tests, oddly.
+           * FIXME: If this plugin used formatters, a BR would be inserted
+           * automatically.
+           */
+          if (parentNode.childNodes.length === 0) {
+            var brElement = document.createElement('br');
+            parentNode.appendChild(brElement);
+          }
         } else {
           throw new Error('Cannot empty non-text node!');
         }


### PR DESCRIPTION
Given an empty editor, when you type a prefix, you lose your selection because
the LI has no BR element inside it.

Oddly, in the tests a BR element is added. I couldn't figure out why they behave
differently.
