### PR TITLE
Refer to Scribe source by version, not master

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "requirejs": "~2.1.9",
-    "scribe": "guardian/scribe#master"
+    "scribe": "guardian/scribe#v0.1.17-src"
   },
   "version": "0.1.2"
 }


### PR DESCRIPTION
The example and tests use the source files of Scribe so that you can easily
`bower link` Scribe and it will just work.

However, we currently point to the `master` branch. This is bad because it
breaks backwards compatibility: if I checkout a commit on `master` from a month
ago and then run the tests, it likely won't work because Scribe’s `master` will
have moved.

I'm proposing that we always tag releases along the `master` branch as well as
the `dist` branch, so that we can depend on the source files by version. We can
continue to use semver tags on the `dist` branch, as this has the most
user-friendly consumer experience (meaning: you don't have to setup paths to
Scribe’s dependencies), whilst tagging releases on the `master` branch with a
different format for the tag name.

Can anyone think of any disadvantages to this? I want to get it right because it
is something we should eventually use across all Scribe plugins.

Notes:
* The tags are still picked up by Bower (`bower info scribe`; I imagine this is
  because `x.x.x-src` is still valid semver – is it?), however `bower install
  --save` still picks the `dist` tags.