### PR TITLE
Add missing `DOCTYPE` to fix issue with Chrome losing focus

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,67 +1,73 @@
-<!--
-Note that you'll need to install scribe's dependencies through
-`bower install`. See http://bower.io/ if you are unfamiliar.
--->
-<style>
-  button {
-    height: 3em;
-  }
+<!DOCTYPE html>
+<html>
+  <body>
+    <!--
+    Note that you'll need to install scribe's dependencies through
+    `bower install`. See http://bower.io/ if you are unfamiliar.
+    -->
+    <style>
+      button {
+        height: 3em;
+      }
 
-  .active {
-    border-style: inset;
-  }
+      .active {
+        border-style: inset;
+      }
 
-  .rte {
-    display: block;
-  }
+      .rte {
+        display: block;
+      }
 
-  p {
-    margin-top: 0;
-  }
+      p {
+        margin-top: 0;
+      }
 
-  .rte {
-    border: 1px solid gray;
-    height: 300px;
-    overflow: auto;
-  }
-  .rte-output {
-    width: 100%;
-    height: 10em;
-  }
-</style>
-<script src="./bower_components/requirejs/require.js"></script>
-<script>
-/*global window, require*/
-require({
-  paths: {
-    'scribe-common': './bower_components/scribe-common',
-    'lodash-amd': './bower_components/lodash-amd'
-  }
-}, [
-  './bower_components/scribe/src/scribe',
-  './src/scribe-plugin-smart-lists'
-], function (
-  Scribe,
-  scribePluginSmartLists
-) {
-  var scribe = new Scribe(window.document.querySelector('.rte'));
-  window.scribe = scribe;
+      .rte {
+        border: 1px solid gray;
+        height: 300px;
+        overflow: auto;
+      }
+      .rte-output {
+        width: 100%;
+        height: 10em;
+      }
+    </style>
+    <script src="./bower_components/requirejs/require.js"></script>
+    <script>
+    /*global window, require*/
+    require({
+      paths: {
+        'scribe-common': './bower_components/scribe-common',
+        'lodash-amd': './bower_components/lodash-amd'
+      }
+    }, [
+      './bower_components/scribe/src/scribe',
+      './src/scribe-plugin-smart-lists'
+    ], function (
+      Scribe,
+      scribePluginSmartLists
+    ) {
+      var scribe = new Scribe(window.document.querySelector('.rte'));
+      window.scribe = scribe;
 
-  scribe.setContent('<p>Hello, World!<\/p>');
+      scribe.setContent('<p>Hello, World!<\/p>');
 
-  scribe.use(scribePluginSmartLists());
+      scribe.use(scribePluginSmartLists());
 
-  scribe.on('content-changed', updateHtml);
+      scribe.on('content-changed', updateHtml);
 
-  function updateHtml() {
-    window.document.querySelector('.rte-output').value = scribe.getHTML();
-  }
+      function updateHtml() {
+        window.document.querySelector('.rte-output').value = scribe.getHTML();
+      }
 
-  updateHtml();
-});
-</script>
-<div class="rte"></div>
-<section>
-  <h1>Output</h1>
-  <textarea class="rte-output" readonly></textarea>
-</section>
+      updateHtml();
+    });
+    </script>
+    <div class="rte"></div>
+    <section>
+      <h1>Output</h1>
+      <textarea class="rte-output" readonly></textarea>
+    </section>
+
+  </body>
+</html>


### PR DESCRIPTION
Chrome will only add a BR element when running the `insert{Un,Or}deredList`
command when there is a DOCTYPE: http://jsbin.com/sasec/1/edit

Without the DOCTYPE, the Scribe formatters did add a BR element, but by then the
selection had been lost (because the LI element was empty).
