### PR TITLE
Fixes bug where typing "*notalist* " will create a list

### DIFF
--- a/src/scribe-plugin-smart-lists.js
+++ b/src/scribe-plugin-smart-lists.js
@@ -82,7 +82,8 @@ define(['scribe-common/src/element'], function (element) {
           // Failing Firefox tests
 
           var startOfLineIsUList = isUnorderedListChar(container.textContent[0]);
-          if (isUnorderedListChar(lastChar) && currentChar === 'Space' && startOfLineIsUList) {
+          var cursorIsInSecondPosition = selection.range.endOffset === 1;
+          if (isUnorderedListChar(lastChar) && currentChar === 'Space' && startOfLineIsUList && cursorIsInSecondPosition) {
             listCommand = 'insertUnorderedList';
           }
 

--- a/test/integration/main.spec.js
+++ b/test/integration/main.spec.js
@@ -189,4 +189,16 @@ describe('smart lists plugin', function () {
       });
     });
   });
+
+  when('the user types "*notalist* "', function () {
+    beforeEach(function () {
+      return scribeNode.sendKeys('*notalist* ');
+    });
+
+    it('should not create a list', function () {
+      return scribeNode.getInnerHTML().then(function (innerHTML) {
+        expect(innerHTML).to.have.html('<p>*notalist*&nbsp;</p>');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/guardian/scribe-plugin-smart-lists/issues/14

Adds a check to make sure the cursor is in the right position when typing the space key to create a list.
