### PR TITLE
Scribe Common: remove dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,7 @@
 {
   "name": "scribe-plugin-smart-lists",
   "dependencies": {
-    "lodash-amd": "2.4.1",
-    "scribe-common": "0.0.11"
+    "lodash-amd": "2.4.1"
   },
   "devDependencies": {
     "requirejs": "~2.1.9",

--- a/src/scribe-plugin-smart-lists.js
+++ b/src/scribe-plugin-smart-lists.js
@@ -1,4 +1,4 @@
-define(['scribe-common/src/element'], function (element) {
+define([], function () {
 
   'use strict';
 
@@ -18,17 +18,17 @@ define(['scribe-common/src/element'], function (element) {
       return string === '*' || string === '-' || string === '•';
     }
 
-    function findBlockContainer(node) {
-      while (node && ! element.isBlockElement(node)) {
-        node = node.parentNode;
-      }
-
-      return node;
-    }
-
     return function (scribe) {
 
       var preLastChar, lastChar, currentChar;
+
+      function findBlockContainer(node) {
+        while (node && ! scribe.element.isBlockElement(node)) {
+          node = node.parentNode;
+        }
+
+        return node;
+      }
 
       function removeSelectedTextNode() {
         var selection = new scribe.api.Selection();

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -11,7 +11,6 @@
         paths: {
           // We have to define a path to Scribe otherwise it will load the file
           // but will not pass along the 'scribe' AMD module.
-          'scribe-common': '../../bower_components/scribe-common',
           'lodash-amd': '../../bower_components/lodash-amd',
           'immutable': '../../bower_components/immutable'
 


### PR DESCRIPTION
As the final part of addressing [this issue](https://github.com/guardian/scribe/issues/291) this removes the Scribe Common dependency.

The dependency here was part of finding the parent block element of an element. This might be something that Scribe core should offer.