### PR TITLE
Scribe: Reflect the latest API changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "scribe-plugin-smart-lists",
   "dependencies": {
-    "lodash-amd": "2.4.1"
+    "lodash-amd": "~3.5.0",
+    "immutable": "~3.7.3"
   },
   "devDependencies": {
     "requirejs": "~2.1.9",

--- a/src/scribe-plugin-smart-lists.js
+++ b/src/scribe-plugin-smart-lists.js
@@ -23,7 +23,7 @@ define([], function () {
       var preLastChar, lastChar, currentChar;
 
       function findBlockContainer(node) {
-        while (node && ! scribe.element.isBlockElement(node)) {
+        while (node && ! scribe.node.isBlockElement(node)) {
           node = node.parentNode;
         }
 

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -12,7 +12,7 @@
           // We have to define a path to Scribe otherwise it will load the file
           // but will not pass along the 'scribe' AMD module.
           'lodash-amd': '../../bower_components/lodash-amd',
-          'immutable': '../../bower_components/immutable'
+          'immutable': '../../bower_components/immutable/dist/immutable'
 
         }
       });


### PR DESCRIPTION
`scribe.element` has been removed when the node operations were consolidated within Scribe [causing incompatibility](https://github.com/guardian/scribe/issues/408) between the plugins and Scribe.

This wasn't intentional and will be fixed but in the meantime we might was well update this plugin to reflect the latest Scribe setup.